### PR TITLE
Only require the used lodash functions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["lodash"],
   "presets": ["es2015", "react"]
 }

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Dependencies:
 ```json
 "dependencies": {
   "lodash": "^3.10.0",
-  "react": "^0.14.0",
+  "react": "^15.0.0",
   "react-side-effect": "^1.0.0",
-  "seamless-immutable": "^4.0.0"
+  "seamless-immutable": "^5.0.0"
 },
 ```
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,6 +4,22 @@ Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
+var _isObject2 = require('lodash/isObject');
+
+var _isObject3 = _interopRequireDefault(_isObject2);
+
+var _merge2 = require('lodash/merge');
+
+var _merge3 = _interopRequireDefault(_merge2);
+
+var _forEach2 = require('lodash/forEach');
+
+var _forEach3 = _interopRequireDefault(_forEach2);
+
+var _omit2 = require('lodash/omit');
+
+var _omit3 = _interopRequireDefault(_omit2);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -11,10 +27,6 @@ var _react2 = _interopRequireDefault(_react);
 var _reactSideEffect = require('react-side-effect');
 
 var _reactSideEffect2 = _interopRequireDefault(_reactSideEffect);
-
-var _lodash = require('lodash');
-
-var _lodash2 = _interopRequireDefault(_lodash);
 
 var _seamlessImmutable = require('seamless-immutable');
 
@@ -27,7 +39,7 @@ var DocumentModifier = function DocumentModifier(props) {
 		return _react2.default.Children.only(props.children);
 	}
 
-	var divProps = _lodash2.default.omit(props, 'properties');
+	var divProps = (0, _omit3.default)(props, 'properties');
 
 	return _react2.default.Children.count(props.children) > 1 ? _react2.default.createElement(
 		'div',
@@ -42,16 +54,16 @@ DocumentModifier.propTypes = {
 };
 
 function reducePropsToState() {
-	var propsList = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
+	var propsList = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
 
 	var finalProps = {}; //our goal is return the final document.`props` tree for the current application state - this is a "pure" function
 
 	//This will traverse the tree, starting with the highest-most component and working its way down through all the children.
-	_lodash2.default.forEach(propsList, function (props) {
+	(0, _forEach3.default)(propsList, function (props) {
 		//At each level, we will merge into `props` from the `properties` attribute - overwriting any parent-ly set values
 		//This means that the further nested component's properties will win,
 		//whilst still preserving parent properties that never get overwritten
-		_lodash2.default.merge(finalProps, props.properties);
+		(0, _merge3.default)(finalProps, props.properties);
 	});
 
 	return finalProps;
@@ -59,16 +71,16 @@ function reducePropsToState() {
 
 //UTILITIES
 function deepDOMUpdate(target, source) {
-	var domNode = arguments.length <= 2 || arguments[2] === undefined ? document : arguments[2];
-	var defaultClear = arguments.length <= 3 || arguments[3] === undefined ? '' : arguments[3];
+	var domNode = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : document;
+	var defaultClear = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : '';
 
 	//This function will update the `domNode` (and its child properties), as described by the `target`
 	//The `source` is used to mark (and clear) props that were removed in the last reduce
 
 	var result = target.asMutable(); //we will return the new `virtualDocumentProps`
 
-	_lodash2.default.forEach(target, function (value, key) {
-		if (_lodash2.default.isObject(value)) {
+	(0, _forEach3.default)(target, function (value, key) {
+		if ((0, _isObject3.default)(value)) {
 			deepDOMUpdate(target[key], source[key], domNode[key]); //if it's an object, then recurse
 		} else {
 			result[key] = source ? source[key] : undefined; //clear out a now null property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-document-modifier",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "Declaritive, nested, stateful `document` modification for React applications",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
Rather than require the entire lodash library just require the individual modules/functions used.

Correct the package versions in the readme
